### PR TITLE
Added availability zone support for service templates and removed static VM flavor constraints

### DIFF
--- a/contrail_heat/env/service_chain.env
+++ b/contrail_heat/env/service_chain.env
@@ -3,6 +3,7 @@ parameters:
   policy_name: contrail_policy
   direction: "<>"
   private_template: default-domain:contrail_svc_temp1
+  private_availability_zone: ""
   private_net_1_name: contrail_net1
   private_net_1_cidr: 1.1.1.0/24
   private_net_1_pool_end: 1.1.1.254

--- a/contrail_heat/resources/service_instance.py
+++ b/contrail_heat/resources/service_instance.py
@@ -195,6 +195,8 @@ class HeatServiceInstance(ContrailResource):
                                                 auto_scale=auto_scale)
         si_prop.set_scale_out(scale_out)
 
+        si_prop.set_availability_zone(self.properties[self.AVAILABILITY_ZONE])
+
         si_prop.set_ha_mode(self.properties[self.HA_MODE])
         si_obj.set_service_instance_properties(si_prop)
 

--- a/contrail_heat/resources/service_template.py
+++ b/contrail_heat/resources/service_template.py
@@ -105,9 +105,6 @@ class HeatServiceTemplate(ContrailResource):
             properties.Schema.STRING,
             _('Indicates service VM flavor'),
             update_allowed=False,
-            constraints=[
-                constraints.AllowedValues(['m1.tiny', 'm1.small', 'm1.medium', 'm1.large', 'm1.xlarge']),
-            ],
             required=True,
         ),
         ORDERED_INTERFACES: properties.Schema(
@@ -167,6 +164,7 @@ class HeatServiceTemplate(ContrailResource):
             svc_properties.set_availability_zone_enable(False)
         svc_properties.set_service_mode(self.properties[self.SERVICE_MODE])
         svc_properties.set_service_type(self.properties[self.SERVICE_TYPE])
+        svc_properties.set_availability_zone_enable(self.properties[self.AVAILABILITY_ZONE_ENABLE])
         svc_properties.set_service_virtualization_type(
             self.properties[self.SERVICE_VIRT_TYPE])
         svc_properties.set_ordered_interfaces(

--- a/contrail_heat/template/service_chain.yaml
+++ b/contrail_heat/template/service_chain.yaml
@@ -51,6 +51,10 @@ parameters:
     type: string
     default: TestInstance1
     description: service instance name
+  private_availability_zone:
+    type: string
+    default: ""
+    description: availability zone in form of Zone:Host
 
 resources:
   private_net_1:
@@ -91,6 +95,7 @@ resources:
     properties:
       name: { get_param: private_instance_name }
       service_template: { get_param:  private_template}
+      availability_zone: { get_param: private_availability_zone}
       scale_out: 
           max_instances: 1
       interface_list: [


### PR DESCRIPTION
- Added support for availability zones to be defined in service instances via service templates.
- Removed constraints check on VM flavor against the default openstack flavor's. Flavors are created/deleted and modified by admins