### PR TITLE
fix virtual_DNS_read case typo

### DIFF
--- a/generated/resources/virtual_DNS_record_heat.py
+++ b/generated/resources/virtual_DNS_record_heat.py
@@ -128,9 +128,9 @@ class ContrailVirtualDnsRecord(contrail.ContrailResource):
         parent_obj = None
         if parent_obj is None and self.properties.get(self.VIRTUAL_DNS):
             try:
-                parent_obj = self.vnc_lib().virtual_dns_read(id=self.properties.get(self.VIRTUAL_DNS))
+                parent_obj = self.vnc_lib().virtual_DNS_read(id=self.properties.get(self.VIRTUAL_DNS))
             except vnc_api.NoIdError:
-                parent_obj = self.vnc_lib().virtual_dns_read(fq_name_str=self.properties.get(self.VIRTUAL_DNS))
+                parent_obj = self.vnc_lib().virtual_DNS_read(fq_name_str=self.properties.get(self.VIRTUAL_DNS))
             except:
                 parent_obj = None
 


### PR DESCRIPTION
I found the issue with wrong case in the name of the method in older deployment, based on this: https://github.com/Juniper/contrail-heat/search?utf8=%E2%9C%93&q=virtual_dns_read&type= I guess it's still valid. 

Ovbiously CI is not set properly for vDNS.